### PR TITLE
r515: libos log buffers need a pte array

### DIFF
--- a/drivers/gpu/drm/nouveau/include/nvkm/subdev/gsp.h
+++ b/drivers/gpu/drm/nouveau/include/nvkm/subdev/gsp.h
@@ -5,6 +5,8 @@
 #include <core/falcon.h>
 #include <core/firmware.h>
 
+#include <linux/debugfs.h>
+
 #define GPC_MAX 32
 #define GSP_MAX_ENGINES 0x34
 
@@ -65,6 +67,17 @@ struct nvkm_gsp {
 	struct nvkm_gsp_mem loginit;
 	struct nvkm_gsp_mem logrm;
 	struct nvkm_gsp_mem rmargs;
+
+	/*
+	 * Logging buffers in debugfs.  The wrapper objects need to remain
+	 * in memory until the dentry is deleted.
+	 *
+	 * Note that the top-level dentry is stored as global variable
+	 * gsp_debugfs_logging_dir.
+	 */
+	struct debugfs_blob_wrapper blob_init;
+	struct debugfs_blob_wrapper blob_rm;
+	struct debugfs_blob_wrapper blob_pmu;
 
 	struct {
 		struct nvkm_gsp_mem mem;

--- a/drivers/gpu/drm/nouveau/nouveau_drm.c
+++ b/drivers/gpu/drm/nouveau/nouveau_drm.c
@@ -98,6 +98,13 @@ static struct drm_driver driver_stub;
 static struct drm_driver driver_pci;
 static struct drm_driver driver_platform;
 
+/*
+ * Dentry for the GSP logging debugfs files.  We don't want to remove these
+ * debugfs entries until the driver is unloaded, otherwise we can't debug
+ * GSP-RM failures.
+ */
+struct dentry *gsp_debugfs_logging_dir;
+
 static u64
 nouveau_pci_name(struct pci_dev *pdev)
 {
@@ -1366,6 +1373,8 @@ nouveau_drm_init(void)
 static void __exit
 nouveau_drm_exit(void)
 {
+	debugfs_remove(gsp_debugfs_logging_dir);
+
 	if (!nouveau_modeset)
 		return;
 


### PR DESCRIPTION
The LOGINIT and LOGRM buffers may be physically contiguous, but they
still need an array of PTEs embedded in the first page of the buffer.

These buffers are used by GSP-RM to send printf-style logs to Nouveau.
This fix is required in order for GSP-RM to operate correctly.

Signed-off-by: Timur Tabi <ttabi@nvidia.com>